### PR TITLE
Pin to full length SHAs & add Dependabot Updates for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
-          # Block pull requests with vulnerabilities at moderate severity or higher
+          # Block pull requests with vulnerabilities at low severity or higher
           fail-on-severity: low
           # Post detailed summary in PR comments
           comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.8.2
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           # Block pull requests with vulnerabilities at moderate severity or higher
           fail-on-severity: low

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       
@@ -106,7 +106,7 @@ jobs:
           git tag ${{ steps.next_version.outputs.version }}
           git push origin ${{ steps.next_version.outputs.version }}
       
-      - uses: cli/gh-extension-precompile@v2.1.0
+      - uses: cli/gh-extension-precompile@9e2237c30f869ad3bcaed6a4be2cd43564dd421b # v2.1.0
         with:
           go_version_file: go.mod
           generate_attestations: true


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

This PR pins all actions to full length SHAs, and adds a dependabot.yml file to trigger weekly Dependabot PRs for Actions versions.

## Release Type

<!-- Check one box to indicate the type of semantic version bump -->

- [ ] **Major** - Breaking changes
- [ ] **Minor** - New features, backwards compatible
- [x] **Patch** - Bug fixes, backwards compatible